### PR TITLE
Bump mssqlserver-compact3.5 version

### DIFF
--- a/mssqlserver-compact3.5/Tools/chocolateyInstall.ps1
+++ b/mssqlserver-compact3.5/Tools/chocolateyInstall.ps1
@@ -7,9 +7,9 @@ $packageParameters = @{
   fileFullPath = Join-Path $options['tempDir'] "SSCERuntime-ENUInstall.exe";
   url = 'http://download.microsoft.com/download/E/C/1/EC1B2340-67A0-4B87-85F0-74D987A27160/SSCERuntime-ENU.exe';
   url64bit = 'http://download.microsoft.com/download/E/C/1/EC1B2340-67A0-4B87-85F0-74D987A27160/SSCERuntime-ENU.exe';
-  checksum = '3FC0F90836A5080E5136262A715A826CB13DC1F2506094F65C69E63A5AD4CC4D';
+  checksum = '2B15E1FAB3533E9C3807184B741A24B4A66C24664432BF6B6177FEFBD1BCE6E3';
   checksumType = 'Sha256';
-  checksum64 = '3FC0F90836A5080E5136262A715A826CB13DC1F2506094F65C69E63A5AD4CC4D';
+  checksum64 = '2B15E1FAB3533E9C3807184B741A24B4A66C24664432BF6B6177FEFBD1BCE6E3';
   checksumType64 = 'Sha256';
 }
 
@@ -18,7 +18,7 @@ try {
 
   Get-ChocolateyWebFile @packageParameters
 
-  Start-Process "$($packageParameters['fileFullPath'])" -ArgumentList "/T:$($options['tempDir']) /q" -Wait
+  Start-Process "$($packageParameters['fileFullPath'])" -ArgumentList @("/T:`"$($options['tempDir'])`"", "/q") -Wait
 
   try {
     Install-ChocolateyPackage 'mssqlserver-compact3.5-x32' 'msi' '/quiet /passive' (Join-Path $options['tempDir'] 'SSCERuntime_x86-ENU.msi') ''

--- a/mssqlserver-compact3.5/mssqlserver-compact3.5.nuspec
+++ b/mssqlserver-compact3.5/mssqlserver-compact3.5.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <version>3.5.5386.2</version>
+    <version>3.5.8080.0</version>
     <authors>Microsoft</authors>
     <owners>Ritch Melton</owners>
     <projectUrl>http://www.microsoft.com/sqlserver/en/us/default.aspx</projectUrl>


### PR DESCRIPTION
- Bump mssqlserver-compact3.5 to version 3.5.8080.0 (same URL as before)
- Quote extraction path argument to handle spaces in pathnames